### PR TITLE
Cleanup the frontpage from HTML

### DIFF
--- a/pages/homepage/modules/ROOT/pages/index.adoc
+++ b/pages/homepage/modules/ROOT/pages/index.adoc
@@ -1,47 +1,27 @@
 = CentOS Documentation Home
-:page-layout: frontpage
 
-++++
-<div class="homepage-page">
-    <div class="homepage-section homepage-section-user-docs">
-        <h2>CentOS Stream Documentation</h2>
-        <div class="homepage-section-container">
-            <a href="../stream-contrib/" class="homepage-link homepage-link-primary">
-                <h3>Contributor's Guide</h3>
-                <p>Documentation for those who want to contribute to CentOS Stream.</p>
-            </a>
-        </div>
-    </div>
-</div>
-<div class="homepage-page">
-    <div class="homepage-section homepage-section-user-docs">
-        <h2>CentOS 8 User Documentation</h2>
-        <div class="homepage-section-container">
-            <a href="../8-docs/" class="homepage-link homepage-link-primary">
-                <h3>Installation and Admin Documentation</h3>
-                <p>Standard and advanced install instructions and AppStream documentation for CentOS 8.</p>
-            </a>
-            <a href="https://wiki.centos.org/Manuals/ReleaseNotes/CentOSLinux8" class="homepage-link homepage-link-primary">
-                <h3>🔗 Release Notes</h3>
-                <p>Release Notes for every version of CentOS 8.</p>
-            </a>
-        </div>
-    </div>
-</div>
+== CentOS Stream Documentation
 
-<div class="homepage-page">
-    <div class="homepage-section homepage-section-user-docs">
-        <h2>CentOS 7 User Documentation</h2>
-        <div class="homepage-section-container">
-            <a href="../centos/install-guide/" class="homepage-link homepage-link-primary">
-                <h3>Installation Guide</h3>
-                <p>Instructions for installing CentOS 7 on various architectures.</p>
-            </a>
-            <a href="https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7" class="homepage-link homepage-link-primary">
-                <h3>🔗 Release Notes</h3>
-                <p>Release Notes for every version of CentOS 7.</p>
-            </a>
-        </div>
-    </div>
-</div>
-++++
+=== link:../stream-contrib/[Contributor's Guide]
+
+Documentation for those who want to contribute to CentOS Stream.
+
+== CentOS 8 User Documentation
+
+=== link:../8-docs/[Installation and Admin Documentation]
+
+Standard and advanced install instructions and AppStream documentation for CentOS 8.
+
+=== link:https://wiki.centos.org/Manuals/ReleaseNotes/CentOSLinux8[🔗 Release Notes]
+
+Release Notes for every version of CentOS 8.
+
+== CentOS 7 User Documentation
+
+=== link:../7-docs/[Installation Guide]
+
+Instructions for installing CentOS 7 on various architectures.
+
+=== https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7[🔗 Release Notes]
+
+Release Notes for every version of CentOS 7.


### PR DESCRIPTION
CentOS front page is not using any additional CSS tweaks, thus the html elements are redundant. They can be removed and replaced with standard Asciidoc content.

This change doesn't introduce any change in the content or hierarchy, it only simplifies the source for the front page.